### PR TITLE
fix: Removido 0 e colocado espaço em branco segmentoP

### DIFF
--- a/src/Cnab/Remessa/Cnab240/Banco/Bb.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bb.php
@@ -201,7 +201,7 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(78, 85, $boleto->getDataVencimento()->format('dmY'));
         $this->add(86, 100, Util::formatCnab('9', $boleto->getValor(), 15, 2));
         $this->add(101, 105, '00000');
-        $this->add(106, 106, '0');
+        $this->add(106, 106, ' ');
         $this->add(107, 108, Util::formatCnab('9', $boleto->getEspecieDocCodigo(), 2));
         $this->add(109, 109, Util::formatCnab('9', $boleto->getAceite(), 1));
         $this->add(110, 117, $boleto->getDataDocumento()->format('dmY'));

--- a/tests/Remessa/RemessaCnab240Test.php
+++ b/tests/Remessa/RemessaCnab240Test.php
@@ -184,4 +184,8 @@ class RemessaCnab240Test extends TestCase
         $file2 = $remessa->save($file);
         $this->assertEquals($file, $file2);
     }
+
+
+
+
 }


### PR DESCRIPTION
### Descricao breve da PR: (obrigatório)
- Corrigido Segmento P, é necessário ter espaço em branco nas posições 106 do Segmento P, segundo o manual do Banco do Brasil para cnab240
![image](https://github.com/Equipe-Proesc/laravel-boleto/assets/66711752/a8f8375c-e7ab-4f29-91ad-098644eefde2)
## Exemplos de como testar a PR: (obrigatório)
## Imagens anexas: (opcional)
