### PR TITLE
feat: adicionado campos de mensagem 1 e mensagem 2 na lib

### DIFF
--- a/src/Boleto/AbstractBoleto.php
+++ b/src/Boleto/AbstractBoleto.php
@@ -370,6 +370,16 @@ abstract class AbstractBoleto implements BoletoContract
      *
      * @throws \Exception
      */
+
+    /**
+     * @var string
+     */
+    private $mensagem1;
+    /**
+     * @var string
+     */
+    private $mensagem2;
+
     public function __construct($params = [])
     {
         Util::fillClass($this, $params);
@@ -1721,6 +1731,44 @@ abstract class AbstractBoleto implements BoletoContract
         return $this;
     }
 
+
+
+    /**
+     * @param $mensagem
+     * @return AbstractBoleto
+     */
+    public function  setMensagem1($mensagem)
+    {
+        $this->mensagem1 = $mensagem;
+        return $this;
+    }
+
+    /**
+     * @param $mensagem
+     * @return AbstractBoleto
+     */
+    public  function  setMensagem2($mensagem)
+    {
+        $this->mensagem2 = $mensagem;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getMensagem1()
+    {
+        return $this->mensagem1? $this->mensagem1 : '';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getMensagem2()
+    {
+        return $this->mensagem2? $this->mensagem2 : '';
+    }
+
     /**
      * @return mixed
      */
@@ -1946,6 +1994,8 @@ abstract class AbstractBoleto implements BoletoContract
                     'endereco2' => $this->getPagador()->getCepCidadeUf(),
                     'endereco_completo' => $this->getPagador()->getEnderecoCompleto(),
                 ],
+                'mensagem1'=> $this->getMensagem1(),
+                'mensagem2' => $this->getMensagem2(),
                 'demonstrativo' => $this->getDescricaoDemonstrativo(),
                 'instrucoes' => $this->getInstrucoes(),
                 'instrucoes_impressao' => $this->getInstrucoesImpressao(),

--- a/src/Cnab/Remessa/AbstractRemessa.php
+++ b/src/Cnab/Remessa/AbstractRemessa.php
@@ -137,6 +137,14 @@ abstract class AbstractRemessa
      * @var PessoaContract
      */
     protected $beneficiario;
+    /**
+     * @var string
+     */
+    private $mensagem1;
+    /**
+     * @var string
+     */
+    private $mensagem2;
 
     /**
      * Construtor
@@ -501,6 +509,41 @@ abstract class AbstractRemessa
         return collect($this->aRegistros[self::DETALHE]);
     }
 
+    /**
+     * @param $mensagem
+     * @return AbstractRemessa
+     */
+    public function  setMensagem1($mensagem)
+    {
+        $this->mensagem1 = $mensagem;
+        return $this;
+    }
+
+    /**
+     * @param $mensagem
+     * @return AbstractRemessa
+     */
+    public  function  setMensagem2($mensagem)
+    {
+        $this->mensagem2 = $mensagem;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getMensagem1()
+    {
+        return $this->mensagem1? $this->mensagem1 : '';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getMensagem2()
+    {
+        return $this->mensagem2? $this->mensagem2 : '';
+    }
     /**
      * Retorna o trailer do arquivo.
      *

--- a/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
@@ -357,7 +357,8 @@ class Caixa extends AbstractRemessa implements RemessaContract
         $this->add(66, 72, '0000000');
         $this->add(73, 73, '0');
         $this->add(74, 103, Util::formatCnab('X', $this->getBeneficiario()->getNome(), 30));
-        $this->add(104, 183, '');
+        $this->add(104, 143, $this->getMensagem1());
+        $this->add(144, 183,  $this->getMensagem2());
         $this->add(184, 191, Util::formatCnab('9', $this->getIdremessa(), 8));
         $this->add(192, 199, date('dmY'));
         $this->add(200, 207, '00000000');

--- a/tests/Remessa/CaixaCnab240Test.php
+++ b/tests/Remessa/CaixaCnab240Test.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Eduardokum\LaravelBoleto\Tests\Remessa;
+
+use Eduardokum\LaravelBoleto\Boleto\Banco\Caixa;
+use Eduardokum\LaravelBoleto\Pessoa;
+use Eduardokum\LaravelBoleto\Tests\TestCase;
+
+class CaixaCnab240Test extends  TestCase
+{
+
+
+    protected static $pagador;
+    protected static $beneficiario;
+
+    /**
+     * @return void
+     */
+    public static function setUpBeforeClass(): void
+    {
+        self::$beneficiario = new Pessoa(
+            [
+                'nome' => 'COLÉGIO CRISTÃO MOC',
+                'endereco' => 'Rua um, 123',
+                'cep' => '39402209',
+                'uf' => 'MG',
+                'cidade' => 'MONTES CLAROS',
+                'documento' => '21.365.374/0001-80',
+            ]
+        );
+
+        self::$pagador = new Pessoa(
+            [
+                'nome' => 'ALUNO TESTE DO PROESC',
+                'endereco' => 'AVENIDA JOSE FERREIRA DO AMARAL',
+                'bairro' => 'SAO LAZARO',
+                'cep' => '68908420',
+                'uf' => 'MG',
+                'cidade' => 'MACAPA',
+                'documento' => '72613595990',
+            ]
+        );
+    }
+
+
+    /**
+     * @throws \Exception
+     */
+    public function test_tipo_de_inscricao_do_beneficiario()
+    {
+
+        $linhaSegmento = 1;
+
+        $boleto = new Caixa();
+        $boleto->setLogo(realpath(__DIR__ . '/../logos/') . DIRECTORY_SEPARATOR . '104.png')
+            ->setDataVencimento(new \Carbon\Carbon())
+            ->setValor('200')
+            ->setNumero(717230357272)
+            ->setNumeroDocumento(717230357272)
+            ->setCarteira('RG')
+            ->setAgencia('3115')
+            ->setConta('1416')
+            ->setCodigoCliente(1416)
+            ->setMulta(1)
+            ->setJuros(1)
+            ->setPagador(self::$pagador)
+            ->setDescricaoDemonstrativo([])
+            ->setInstrucoes([]);
+
+
+        $remessa = new \Eduardokum\LaravelBoleto\Cnab\Remessa\Cnab400\Banco\Caixa([
+            'agencia' => '3115',
+            'carteira' => 'RG',
+            'conta' => '1416',
+            'beneficiario' => self::$beneficiario,
+            'Idremessa' => 1,
+            'codigoCliente' => '1416'
+        ]);
+        $remessa->addBoleto($boleto);
+
+        $file = implode(DIRECTORY_SEPARATOR, [
+            __DIR__,
+            'files',
+            'cnab240',
+            'caixa.txt'
+        ]);
+
+        $file2 = $remessa->save($file);
+        $arrayArquivo = file($file2, FILE_IGNORE_NEW_LINES);
+        $conteudo = $arrayArquivo[1];
+
+        $indentificaoDistribuicao = substr($conteudo, 18, 1);
+        $this->assertEquals('1', $indentificaoDistribuicao);
+    }
+
+    public function testBoletoLine()
+    {
+
+        $linhaSegmento = 1;
+
+        $boleto = new Caixa();
+        $boleto->setLogo(realpath(__DIR__ . '/../logos/') . DIRECTORY_SEPARATOR . '104.png')
+            ->setDataVencimento(new \Carbon\Carbon())
+            ->setValor('200')
+            ->setNumero(717230357272)
+            ->setNumeroDocumento(717230357272)
+            ->setCarteira('RG')
+            ->setAgencia('3115')
+            ->setConta('1416')
+            ->setCodigoCliente(1416)
+            ->setMulta(1)
+            ->setJuros(1)
+            ->setPagador(self::$pagador)
+            ->setDescricaoDemonstrativo([])
+            ->setInstrucoes([]);
+
+
+        $remessa = new \Eduardokum\LaravelBoleto\Cnab\Remessa\Cnab400\Banco\Caixa([
+            'agencia' => '3115',
+            'carteira' => 'RG',
+            'conta' => '1416',
+            'beneficiario' => self::$beneficiario,
+            'Idremessa' => 1,
+            'codigoCliente' => '1416'
+        ]);
+        $remessa->addBoleto($boleto);
+
+        $file = implode(DIRECTORY_SEPARATOR, [
+            __DIR__,
+            'files',
+            'cnab240',
+            'caixa.txt'
+        ]);
+
+        $file2 = $remessa->save($file);
+        $arrayArquivo = file($file2, FILE_IGNORE_NEW_LINES);
+        $conteudo = $arrayArquivo[1];
+
+        $indentificaoDistribuicao = substr($conteudo, 18, 1);
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function test_mensagem_caixa()
+    {
+        $linhaHeader = 1;
+
+        $boleto = new Caixa();
+        $boleto->setLogo(realpath(__DIR__ . '/../logos/') . DIRECTORY_SEPARATOR . '104.png')
+            ->setDataVencimento(new \Carbon\Carbon())
+            ->setValor('200')
+            ->setNumero(717230357272)
+            ->setNumeroDocumento(717230357272)
+            ->setCarteira('RG')
+            ->setAgencia('3115')
+            ->setConta('1416')
+            ->setCodigoCliente(1416)
+            ->setMulta(1)
+            ->setJuros(1)
+            ->setPagador(self::$pagador)
+            ->setDescricaoDemonstrativo([])
+            ->setInstrucoes([]);
+        $remessa = new \Eduardokum\LaravelBoleto\Cnab\Remessa\Cnab240\Banco\Caixa([
+            'agencia' => '3115',
+            'carteira' => 'RG',
+            'conta' => '1416',
+            'beneficiario' => self::$beneficiario,
+            'Idremessa' => 1,
+            'codigoCliente' => '1416',
+            'mensagem1' =>'xxxxx'
+        ]);
+        $remessa->addBoleto($boleto);
+
+        $file = implode(DIRECTORY_SEPARATOR, [
+            __DIR__,
+            'files',
+            'cnab240',
+            'caixa.txt'
+        ]);
+
+        $file2 = $remessa->save($file);
+        $arrayArquivo = file($file2, FILE_IGNORE_NEW_LINES);
+       $this->assertTrue(str_contains($arrayArquivo[$linhaHeader],'xxxxx'));
+    }
+
+
+}


### PR DESCRIPTION
## Descricao breve da PR: (obrigatório)
Adicionados campos de mensagem 1 e 2 na laravel boletos. Métodos criado em classe genérica ja abstraída para aplicar em outros bancos.\
![image](https://github.com/Equipe-Proesc/laravel-boleto/assets/66711752/d7ee3d5a-a2a4-4ba2-9001-fc14d75845cf)
## Exemplos de como testar a PR: (obrigatório)
`./vendor/bin/phpunit tests/Remessa`\
O campo de header se localiza na segunda linha da remessa, usei `str_contains` para verificar nos testes.\

![image](https://github.com/Equipe-Proesc/laravel-boleto/assets/66711752/5ba58cf8-7301-462f-8194-4a54a890c985)
